### PR TITLE
ci: update workflows and make use of recent Node.js versions

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -8,13 +8,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [16]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,19 +11,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [16]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build:docs
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.0.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs # The folder the action should deploy.

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -8,18 +8,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [16, 18, 19]
+
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test
-      - uses: paambaati/codeclimate-action@v2.7.5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
+#      - if: matrix.node-version == '16'
+#        uses: paambaati/codeclimate-action@v3.2.0
+#        env:
+#          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -21,7 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test
-#      - if: matrix.node-version == '16'
-#        uses: paambaati/codeclimate-action@v3.2.0
-#        env:
-#          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
+      - if: matrix.node-version == '16'
+        uses: paambaati/codeclimate-action@v3.2.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Release
         uses: docker://antonyurchenko/git-release:latest


### PR DESCRIPTION
This PR assumes #11 to be accepted and updates GitHub workflows accordingly.

Primarily, Node.js 16 is used to run those actions.

Furthermore, matrix testing is enabled for recent LTS versions (v16, v18) as well as Current  aka. v19.

The CI changes have been tested successfully:
- https://github.com/wheinze/craftzing-node-akeneo-api/actions/runs/3510061682
- https://github.com/wheinze/craftzing-node-akeneo-api/actions/runs/3510061683

Note: When testing `.github/workflows/quality-assurance.yml`, the Code Climate action has been deactivated due to missing credentials. (That's why https://github.com/wheinze/craftzing-node-akeneo-api/actions/runs/3510070788 was failing on my side after re-enabling it again)