### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,3 @@ jobs:
           PRE_RELEASE: 'false'
           CHANGELOG_FILE: 'CHANGELOG.md'
           ALLOW_EMPTY_CHANGELOG: 'false'
-          ALLOW_TAG_PREFIX: 'true'


### PR DESCRIPTION
It seems that `ALLOW_TAG_PREFIX` has been deprecated: https://github.com/craftzing/node-akeneo-api/actions/runs/3521314330/jobs/5903035907

As tags are not prefixed anyways,  I would propose to simply remove this param.