### PR TITLE
fix: typo in types  `Product` and `ProductModel`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export type ProductModel = {
   created: string;
   updated: string;
   associations: Record<string, Association>;
-  quantified_assoications: Record<string, Association>;
+  quantified_associations: Record<string, Association>;
   metadata: Record<string, any>;
 };
 
@@ -144,7 +144,7 @@ export type Product = {
   associations: Record<string, Association>;
   created: string;
   updated: string;
-  quantified_assoications: Record<string, Association>;
+  quantified_associations: Record<string, Association>;
   metadata: Record<string, any>;
 };
 


### PR DESCRIPTION
Rather small typo being corrected. 

As I could not find any internal usage of this property, as well as this would now reflect akeneo's REST API responses properly, I would assume it would be safe to NOT treat this as a breaking change for consumers.